### PR TITLE
Fix even/odd classes for rows in the syslog report (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The sylog plugin has been in development for well over a decade with increasing 
 
 --- develop ---
 
+* issue#100: Fix odd/even classes generation in report
 * issue#96: Syslog filtering does not work with some international characters
 * issue#87: Program data is not sync with syslog_incoming under PHP 7.2
 

--- a/syslog_process.php
+++ b/syslog_process.php
@@ -664,13 +664,13 @@ if (cacti_sizeof($reports)) {
 
 				$classes = array('even', 'odd');
 
-				$i = 0;
 				if (cacti_sizeof($items)) {
-					$class = $classes[$i % 2];
+					$i = 0;
 					foreach($items as $item) {
+						$class = $classes[$i % 2];
 						$reptext .= '<tr class="' . $class . '"><td class="host">' . $item['host'] . '</td><td class="date">' . $item['logtime'] . '</td><td class="message">' . html_escape($item['message']) . "</td></tr>\n";
+						$i++;
 					}
-					$i++;
 				}
 
 				if ($reptext != '') {


### PR DESCRIPTION
Only even classes are used. Fix resolves to correct usage of even/odd
clases for even/odd rows within the report